### PR TITLE
Fix#5 Support single unit test

### DIFF
--- a/src/test/java/com/naver/common/RepeatRunner.java
+++ b/src/test/java/com/naver/common/RepeatRunner.java
@@ -3,53 +3,42 @@ package com.naver.common;
 import com.naver.annotation.Repeat;
 
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.Description;
-import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+public class RepeatRunner extends BlockJUnit4ClassRunner {
 
-public class RepeatRunner extends Runner {
-
-    private Class testClass;
-    public RepeatRunner(Class testClass) {
-        super();
-        this.testClass = testClass;
+    public RepeatRunner(Class<?> klass) throws InitializationError {
+        super(klass);
     }
 
     @Override
-    public Description getDescription() {
-        return Description.createTestDescription(this.testClass,
-                "This class is extended class from Runner. \n" +
-                      "This helps test functions running N times with @Repeat(N) annotations");
-    }
-
-    @Override
-    public void run(RunNotifier notifier) {
-        try {
-            Object testObject = testClass.newInstance();
-            for(Method m : testClass.getMethods()) {
-                if(!m.isAnnotationPresent(Test.class))
-                    continue;
-                int N = !m.isAnnotationPresent(Repeat.class) ? 1 : m.getAnnotation(Repeat.class).value();
-                Assert.assertTrue("Parameter of Repeat(N) should be greater than or equal to 1", N >= 1);
-
-                for(int i = 0 ; i < N ; ++i) {
-                    notifier.fireTestStarted(Description.createTestDescription(
-                            testClass, m.getName()));
-                    m.invoke(testObject);
-                    notifier.fireTestFinished(Description.createTestDescription(
-                            testClass, m.getName()));
+    protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
+        Description desc = describeChild(method);
+        if(isIgnored(method)) {
+            notifier.fireTestIgnored(desc);
+        } else {
+            Statement statement = new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    int count = getCount(method);
+                    for(int i = 0 ; i < count ; ++i)
+                        methodBlock(method).evaluate();
                 }
-            }
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
+            };
+            runLeaf(statement, desc, notifier);
         }
     }
+
+    protected int getCount(FrameworkMethod child) {
+        int count = child.getAnnotation(Repeat.class) == null ? 1 : child.getAnnotation(Repeat.class).value();
+        Assert.assertTrue("Parameter of Repeat(N) should be greater than or equal to 1", count >= 1);
+
+        return count;
+    }
+
 }

--- a/src/test/java/com/naver/test/MyTestClass.java
+++ b/src/test/java/com/naver/test/MyTestClass.java
@@ -2,7 +2,9 @@ package com.naver.test;
 
 import com.naver.annotation.Repeat;
 import com.naver.common.RepeatRunner;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,6 +35,16 @@ public class MyTestClass {
     public void testMyCode10Times() {
         System.out.println("Test my code 10 times...");
         testMyCodeOnce();
+    }
+
+    @Before
+    public void beforeTest() {
+        System.out.println("This is beforeTest function...");
+    }
+
+    @After
+    public void afterTest() {
+        System.out.println("This is afterTest function...");
     }
 
 }


### PR DESCRIPTION
- 상속하는 Class를 Runner에서 BlockJUnit4ClassRunner로 변경
    - runChild함수를 override하여 단일 test 호출 시 수행되는 로직을 구현
    - 기존 BlockJUnit4ClassRunner.runChild에서 evaluate 부분을 수정하여
       Repeat 횟수만큼 반복하도록 구현
- \@Repeat annotaion에서 값을 가져오는 getCount 함수 구현
- repeat되는 test 함수의 실행 예시를 위하여 \@before \@after annotation을
  붙인 함수 추가
- Fix #5 